### PR TITLE
Window Exit Bug

### DIFF
--- a/screen_recorder.py
+++ b/screen_recorder.py
@@ -13,7 +13,6 @@ import time
 import sys
 
 def run():
-    root.destroy()
     # display screen resolution, get it from your OS settings
     SCREEN_SIZE = pyautogui.size()
     # define the codec
@@ -41,6 +40,8 @@ def run():
         # write the frame
         out.write(frame)
     out.release()
+    root.destroy()
+    sys.exit(0)
 
 def screenshot():
     root.destroy()


### PR DESCRIPTION
When choosing to record and then exiting, the tkinter window was persistant, it shows a blank window and the process is not proparly closed. However Screenshot feature works Perfectly as expected. so I used the same system exit code in the record function also and put the destroy function at the end. this seemed to have solved the issue. now after closing the recording by pressing q the tkinter window also closes as expected. Don't know weather the previous behaviour was intentional (so as to record/continue recording more) or not but i figured that it was unintentional as their was a empty tkinter root window still open. However this should solve it. btw Great Work Bro!!